### PR TITLE
Migrate away from deprecated function calls

### DIFF
--- a/src/runner/configureMocha.ts
+++ b/src/runner/configureMocha.ts
@@ -7,18 +7,17 @@ export default function configureMocha(options: MochaWebpackOptions) {
   // infinite stack traces
   Error.stackTraceLimit = Infinity
 
+  const mochaOptions = {
+    color: !!options.colors,
+    inlineDiffs: !!options.useInlineDiffs
+  }
+
   // init mocha
-  const mocha = new Mocha()
+  const mocha = new Mocha(mochaOptions)
 
   // reporter
   const reporter = loadReporter(options.reporter, options.cwd)
   mocha.reporter(reporter, options.reporterOptions)
-
-  // colors
-  mocha.useColors(options.colors)
-
-  // inline-diffs
-  mocha.useInlineDiffs(options.useInlineDiffs)
 
   // slow <ms>
   mocha.suite.slow(options.slow)

--- a/test/unit/runner/configureMocha.test.ts
+++ b/test/unit/runner/configureMocha.test.ts
@@ -26,8 +26,8 @@ describe('configureMocha', function() {
     }
     this.sandbox = sandbox.create()
     this.spyReporter = this.sandbox.spy(Mocha.prototype, 'reporter')
-    this.spyUseColors = this.sandbox.spy(Mocha.prototype, 'useColors')
-    this.spyUseInlineDiffs = this.sandbox.spy(Mocha.prototype, 'useInlineDiffs')
+    this.spyColor = this.sandbox.spy(Mocha.prototype, 'color')
+    this.spyInlineDiffs = this.sandbox.spy(Mocha.prototype, 'inlineDiffs')
     this.spyEnableTimeouts = this.sandbox.spy(Mocha.prototype, 'enableTimeouts')
     this.spyGrep = this.sandbox.spy(Mocha.prototype, 'grep')
     this.spyGrowl = this.sandbox.spy(Mocha.prototype, 'growl')
@@ -60,27 +60,36 @@ describe('configureMocha', function() {
     )
   })
 
-  it('should call useColors()', function() {
-    configureMocha({
-      ...this.options
+  it('should set color', function() {
+    var mocha = configureMocha({
+      ...this.options,
+      colors: undefined
     })
 
-    assert.isTrue(this.spyUseColors.called, 'useColors() should be called')
-    assert.isTrue(this.spyUseColors.calledWith(this.options.colors))
+    assert.isFalse(mocha.options.color)
+
+    mocha = configureMocha({
+      ...this.options,
+      colors: true
+    })
+
+    assert.isTrue(mocha.options.color)
   })
 
-  it('should call useInlineDiffs()', function() {
-    configureMocha({
-      ...this.options
+  it('should set inlineDiffs', function() {
+    var mocha = configureMocha({
+      ...this.options,
+      useInlineDiffs: undefined
     })
 
-    assert.isTrue(
-      this.spyUseInlineDiffs.called,
-      'useInlineDiffs() should be called'
-    )
-    assert.isTrue(
-      this.spyUseInlineDiffs.calledWith(this.options.useInlineDiffs)
-    )
+    assert.isFalse(mocha.options.inlineDiffs)
+
+    mocha = configureMocha({
+      ...this.options,
+      useInlineDiffs: true
+    })
+
+    assert.isTrue(mocha.options.inlineDiffs)
   })
 
   it('should call enableTimeouts()', function() {


### PR DESCRIPTION
**What's the problem this PR addresses?**
Fixes https://github.com/sysgears/mochapack/issues/53
Depends on https://github.com/sysgears/mochapack/pull/58

**How did you fix it?**
- Instead of calling the deprecated functions, provide their arguments as options to the `Mocha` constructor
- Update the test coverage of the options accordingly